### PR TITLE
fix: update keyboard symbols to cross-platform Unicode standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This Obsidian plugin allows you to select text within your notes and, with a sim
 
 ## Features
 
-- **Effortless Formatting:** Select text containing keyboard key names and press a keyboard shortcut of your choosing  to format them. For example`ctrl shift a` will become <kbd>⌘ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>A</kbd>.
+- **Effortless Formatting:** Select text containing keyboard key names and press a keyboard shortcut of your choosing  to format them. For example`ctrl shift a` will become <kbd>⌃ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>A</kbd>.
 - **Special Keys Recognition:**
-   - Common modifier keys: <kbd>&#9096; Ctrl</kbd> <kbd>&#8679; Shift</kbd> <kbd>&#9095; Alt</kbd> <kbd>&#8984; Cmd</kbd> <kbd>Win</kbd> etc.
+   - Common modifier keys: <kbd>⌃ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>⎇ Alt</kbd> <kbd>⌘ Cmd</kbd> <kbd>Win</kbd> etc.
    - Function keys: <kbd>F1</kbd>-<kbd>F12</kbd>
-   - Command keys <kbd>⇥ Tab</kbd>, <kbd>⌫ Delete</kbd> <kbd>⏎ Enter</kbd>
+   - Command keys <kbd>⇥ Tab</kbd>, <kbd>⌦ Delete</kbd> <kbd>⏎ Enter</kbd> <kbd>⌫ Backspace</kbd>
    - Directions like `up` and `left` become <kbd>↑ Up</kbd> <kbd>← Left</kbd> to mimic arrow keys
    - Numpad keys such as `numpad .` or `numpad 5`  will be formatted as <kbd>Numpad&nbsp;•</kbd> or <kbd>Numpad&nbsp;5</kbd>
 - **Mouse Button Formatting:** "lmb" as <kbd>Left 🖱️</kbd>, "rmb" as <kbd>Right 🖱️</kbd>, "mmb" as <kbd>Middle 🖱️</kbd>, and "wheel" or "scrollwheel" as <kbd>Wheel 🖱️</kbd>.
@@ -40,7 +40,37 @@ This Obsidian plugin allows you to select text within your notes and, with a sim
    - Open a Markdown note in Obsidian.
    - Select the text you want to format (e.g., `ctrl shift a`).
    - Press the keyboard shortcut to run the tool
-   - The selected text will be transformed into: `<kbd>⌘ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>A</kbd>` which looks like this: <kbd>⌘ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>A</kbd>.
+   - The selected text will be transformed into: `<kbd>⌃ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>A</kbd>` which looks like this: <kbd>⌃ Ctrl</kbd> <kbd>⇧ Shift</kbd> <kbd>A</kbd>.
+
+## Keyboard Symbols Reference
+
+This plugin uses **cross-platform Unicode symbols** for keyboard keys to ensure consistency across different platforms and applications. Here's the mapping of symbols used:
+
+### Modifier Keys
+| Symbol | Unicode | Key |
+|--------|---------|-----|
+| ⌃ | U+2303 | Control/Ctrl |
+| ⇧ | U+21E7 | Shift |
+| ⎇ | U+2187 | Alt |
+| ⌥ | U+2325 | Option |
+| ⌘ | U+2318 | Command/Cmd |
+
+### Navigation & Special Keys
+| Symbol | Unicode | Key |
+|--------|---------|-----|
+| ⇥ | U+21E5 | Tab |
+| ⏎ | U+23CE | Enter/Return |
+| ⌫ | U+232B | Backspace |
+| ⌦ | U+2326 | Delete |
+| ⇪ | U+21EA | Caps Lock |
+
+### Super/Meta Keys
+| Symbol | Unicode | Key |
+|--------|---------|-----|
+| ❖ | U+2756 | Super |
+| ◆ | U+25C6 | Meta |
+
+---
 
 ## Support My Work
 

--- a/main.ts
+++ b/main.ts
@@ -94,9 +94,9 @@ export default class KeyboardFormatter extends Plugin {
             switch (lowerWord) {
                 // Modifier Keys
                 case "control":
-                case "ctrl": replacement = "&#9096; Ctrl"; break;
+                case "ctrl": replacement = "&#8963; Ctrl"; break;
                 case "shift": replacement = "&#8679; Shift"; break;
-                case "alt": replacement = "&#9095; Alt"; break;
+                case "alt": replacement = "&#8999; Alt"; break;
                 case "caps":
                 case "capslock": replacement = "&#8682; Caps Lock"; break;
 
@@ -108,8 +108,8 @@ export default class KeyboardFormatter extends Plugin {
                 case "super":
                 case "linux":
                 case "linuxkey":
-                case "tuxkey": replacement = "&#8984; Super"; break;
-                case "meta": replacement = "&#9670; Meta"; break;
+                case "tuxkey": replacement = "&#10054; Super"; break;
+                case "meta": replacement = "&#9830; Meta"; break;
                 case "command":
                 case "cmd": replacement = "&#8984; Cmd"; break;
                 case "option":
@@ -123,13 +123,13 @@ export default class KeyboardFormatter extends Plugin {
                     break;
 
                 // Navigation & Special Keys
-                case "tab": replacement = "&#8633; Tab"; break;
+                case "tab": replacement = "&#8677; Tab"; break;
                 case "erase":
                 case "delete":
-                case "del": replacement = "&#9003; Delete"; break;
+                case "del": replacement = "&#9062; Delete"; break;
                 case "enter":
                 case "return": replacement = "&#9166; Enter"; break;
-                case "backspace": replacement = "&#10229; Backspace"; break;
+                case "backspace": replacement = "&#9003; Backspace"; break;
                 case "pageup":
                 case "pgup": replacement = "&#8670; Page Up"; break;
                 case "pagedown":
@@ -196,7 +196,7 @@ class KeyboardFormatterSettingTab extends PluginSettingTab {
         
         const lightCtrlKbd = lightPreviewContent.createEl('kbd', {cls: 'fkt-preview-kbd'});
         // Use textContent for the symbol and text separately to avoid security issues
-        lightCtrlKbd.textContent = '⎈ Ctrl';
+        lightCtrlKbd.textContent = '⌃ Ctrl';
         lightPreviewContent.createSpan(' ');
         lightPreviewContent.createEl('kbd', {cls: 'fkt-preview-kbd', text: 'S'});
         
@@ -206,7 +206,7 @@ class KeyboardFormatterSettingTab extends PluginSettingTab {
         const darkPreviewContent = darkPreview.createEl('div', {cls: 'fkt-preview-content'});
         
         const darkCtrlKbd = darkPreviewContent.createEl('kbd', {cls: 'fkt-preview-kbd'});
-        darkCtrlKbd.textContent = '⎈ Ctrl';
+        darkCtrlKbd.textContent = '⌃ Ctrl';
         darkPreviewContent.createSpan(' ');
         darkPreviewContent.createEl('kbd', {cls: 'fkt-preview-kbd', text: 'S'});
 


### PR DESCRIPTION
## Changes

Updates keyboard symbols to use cross-platform Unicode standards for consistency.

### Symbol Updates:
- **Ctrl**: ⎈ → ⌃ (U+2303)
- **Alt**: Corrected entity code (U+2187)
- **Tab**: ⇱ → ⇥ (U+21E5)
- **Delete**: Corrected entity code (U+2326)
- **Backspace**: ← → ⌫ (U+232B)
- **Super**: ⊞ → ❖ (U+2756)
- **Meta**: Updated to ◆ (U+25C6)

Resolves issue https://github.com/Lauloque/Keyboard-Formatter/issues/1